### PR TITLE
Fix cs checks

### DIFF
--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -151,7 +151,7 @@ class RestControllerFactory implements AbstractFactoryInterface
             $identifier = $config['identifier'];
         }
 
-        $controllerClass = isset($config['controller_class']) ? $config['controller_class'] : 'Laminas\ApiTools\Rest\RestController';
+        $controllerClass = isset($config['controller_class']) ? $config['controller_class'] : RestController::class;
         $controller      = new $controllerClass($identifier);
 
         if (! $controller instanceof RestController) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fixes long line causing cs-check fail (swaps default rest controller name from magic string to actual class constant)