### PR TITLE
Allow `Laminas\Stdlib\Parameters` as parameter type for for `AbstractResourceListener#fetchAll()`

### DIFF
--- a/src/AbstractResourceListener.php
+++ b/src/AbstractResourceListener.php
@@ -181,7 +181,7 @@ abstract class AbstractResourceListener implements ListenerAggregateInterface
                 $id = $event->getParam('id', null);
                 return $this->fetch($id);
             case 'fetchAll':
-                $queryParams = $event->getQueryParams() ?: new Parameters();
+                $queryParams = $event->getQueryParams() ?: [];
                 return $this->fetchAll($queryParams);
             case 'patch':
                 $id   = $event->getParam('id', null);
@@ -253,10 +253,10 @@ abstract class AbstractResourceListener implements ListenerAggregateInterface
     /**
      * Fetch all or a subset of resources
      *
-     * @param  Parameters $params
+     * @param  array|Parameters $params
      * @return ApiProblem|mixed
      */
-    public function fetchAll(Parameters $params)
+    public function fetchAll($params = [])
     {
         return new ApiProblem(405, 'The GET method has not been defined for collections');
     }

--- a/src/AbstractResourceListener.php
+++ b/src/AbstractResourceListener.php
@@ -10,8 +10,8 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\EventManager\ListenerAggregateTrait;
 use Laminas\InputFilter\InputFilterInterface;
-
 use Laminas\Stdlib\Parameters;
+
 use function sprintf;
 
 abstract class AbstractResourceListener implements ListenerAggregateInterface

--- a/src/AbstractResourceListener.php
+++ b/src/AbstractResourceListener.php
@@ -11,6 +11,7 @@ use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\EventManager\ListenerAggregateTrait;
 use Laminas\InputFilter\InputFilterInterface;
 
+use Laminas\Stdlib\Parameters;
 use function sprintf;
 
 abstract class AbstractResourceListener implements ListenerAggregateInterface
@@ -180,7 +181,7 @@ abstract class AbstractResourceListener implements ListenerAggregateInterface
                 $id = $event->getParam('id', null);
                 return $this->fetch($id);
             case 'fetchAll':
-                $queryParams = $event->getQueryParams() ?: [];
+                $queryParams = $event->getQueryParams() ?: new Parameters();
                 return $this->fetchAll($queryParams);
             case 'patch':
                 $id   = $event->getParam('id', null);
@@ -252,10 +253,10 @@ abstract class AbstractResourceListener implements ListenerAggregateInterface
     /**
      * Fetch all or a subset of resources
      *
-     * @param  array $params
+     * @param  Parameters $params
      * @return ApiProblem|mixed
      */
-    public function fetchAll($params = [])
+    public function fetchAll(Parameters $params)
     {
         return new ApiProblem(405, 'The GET method has not been defined for collections');
     }

--- a/test/AbstractResourceListenerTest.php
+++ b/test/AbstractResourceListenerTest.php
@@ -133,4 +133,17 @@ class AbstractResourceListenerTest extends TestCase
 
         $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
     }
+
+    /**
+     * @group 7
+     */
+    public function testDispatchShouldPassEmptyArrayToFetchAllMethodIfNoQueryParamsArePresent()
+    {
+        $event = new ResourceEvent();
+        $event->setName('fetchAll');
+
+        $this->listener->dispatch($event);
+
+        $this->assertEquals([], $this->listener->testCase->paramsPassedToListener);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #27
However it is for discussion only, because it introduces a breaking change in the `api-tools-admin` library:

https://github.com/laminas-api-tools/api-tools-admin/blob/ec65808d6016d5650327d1c4150aeb8dbd735035/view/code-connected/rest-resource.phtml#L52-L61

In order to do this right, we would need to release a new major version of this library and then, later, a new version of `api-tools-admin` with a bumped dependancy to this library on v2.0.0.

Thinking a bit further.. could this problem be avoided in the future by moving template files like :
https://github.com/laminas-api-tools/api-tools-admin/blob/1.11.x/view/code-connected/rest-resource.phtml
to this repository?
